### PR TITLE
Update to Liquibase 3.0, RawSqlChange Implementation

### DIFF
--- a/java-src/clj_liquibase/CustomDBDocVisitor.java
+++ b/java-src/clj_liquibase/CustomDBDocVisitor.java
@@ -17,13 +17,15 @@ import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.visitor.ChangeSetVisitor;
 import liquibase.database.Database;
-import liquibase.database.structure.Column;
-import liquibase.database.structure.DatabaseObject;
-import liquibase.database.structure.Table;
+import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotControl;
+import liquibase.structure.core.Column;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Table;
 import liquibase.dbdoc.AuthorListWriter;
 import liquibase.dbdoc.AuthorWriter;
 import liquibase.dbdoc.ChangeLogListWriter;
-import liquibase.dbdoc.ChangeLogWriter;
 import liquibase.dbdoc.ColumnWriter;
 import liquibase.dbdoc.HTMLWriter;
 import liquibase.dbdoc.PendingChangesWriter;
@@ -36,7 +38,7 @@ import liquibase.exception.DatabaseHistoryException;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
-import liquibase.snapshot.DatabaseSnapshotGeneratorFactory;
+import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.util.StreamUtil;
 
 public class CustomDBDocVisitor implements ChangeSetVisitor {
@@ -128,7 +130,7 @@ public class CustomDBDocVisitor implements ChangeSetVisitor {
         }
     }
 
-    public void writeHTML(File rootOutputDir, ResourceAccessor resourceAccessor) throws IOException, DatabaseException, DatabaseHistoryException {
+    public void writeHTML(File rootOutputDir, ResourceAccessor resourceAccessor) throws IOException, DatabaseException, DatabaseHistoryException, InvalidExampleException {
         //ChangeLogWriter changeLogWriter = new ChangeLogWriter(resourceAccessor, rootOutputDir);
         HTMLWriter authorWriter = new AuthorWriter(rootOutputDir, database);
         HTMLWriter tableWriter = new TableWriter(rootOutputDir, database);
@@ -142,21 +144,21 @@ public class CustomDBDocVisitor implements ChangeSetVisitor {
         copyFile("liquibase/dbdoc/globalnav.html", rootOutputDir);
         copyFile("liquibase/dbdoc/overview-summary.html", rootOutputDir);
 
-        DatabaseSnapshot snapshot = DatabaseSnapshotGeneratorFactory.getInstance().createSnapshot(database, null, null);
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(database.getDefaultSchema(), database, new SnapshotControl(database));
 
         new ChangeLogListWriter(rootOutputDir).writeHTML(changeLogs);
-        new TableListWriter(rootOutputDir).writeHTML(new TreeSet<Object>(snapshot.getTables()));
+        new TableListWriter(rootOutputDir).writeHTML(new TreeSet<Object>(snapshot.get(Table.class)));
         new AuthorListWriter(rootOutputDir).writeHTML(new TreeSet<Object>(changesByAuthor.keySet()));
 
         for (String author : changesByAuthor.keySet()) {
             authorWriter.writeHTML(author, changesByAuthor.get(author), changesToRunByAuthor.get(author), rootChangeLogName);
         }
 
-        for (Table table : snapshot.getTables()) {
+        for (Table table : snapshot.get(Table.class)) {
             tableWriter.writeHTML(table, changesByObject.get(table), changesToRunByObject.get(table), rootChangeLogName);
         }
 
-        for (Column column : snapshot.getColumns()) {
+        for (Column column : snapshot.get(Column.class)) {
             columnWriter.writeHTML(column, changesByObject.get(column), changesToRunByObject.get(column), rootChangeLogName);
         }
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-liquibase "0.4.0"
+(defproject clj-liquibase "0.5.0"
   :description "Clojure wrapper for Liquibase"
   :url "https://github.com/kumarshantanu/clj-liquibase"
   :license {:name "Eclipse Public License"
@@ -11,17 +11,17 @@
   :javac-options {:destdir "target/classes/"
                   :source  "1.5"
                   :target  "1.5"}
-  :dependencies [[org.liquibase/liquibase-core "2.0.5"]
+  :dependencies [[org.liquibase/liquibase-core "3.0.8"]
                  [clj-jdbcutil "0.1.0"]
                  [clj-miscutil "0.4.1"]]
   :profiles {:dev {:dependencies [[oss-jdbc "0.8.0"]
-                                  [clj-dbcp "0.8.0"]]}
+                                  [clj-dbcp "0.8.1"]]}
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-alpha4"]]}}
-  :aliases {"dev" ["with-profile" "dev,1.4"]
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
+  :aliases {"dev" ["with-profile" "dev,1.5"]
             "all" ["with-profile" "dev,1.2:dev,1.3:dev,1.4:dev,1.5"]}
-  :warn-on-reflection true
+  :global-vars {*warn-on-reflection* true}
   :min-lein-version "2.0.0"
   :jvm-opts ["-Xmx1g"])

--- a/src/clj_liquibase/change.clj
+++ b/src/clj_liquibase/change.clj
@@ -1,7 +1,7 @@
 (ns clj-liquibase.change
   "Clojure wrappers for liquibase.change.Change implementations.
   See also:
-    http://www.liquibase.org/manual/home (Available Database Refactorings)"
+    http://www.liquibase.org/documentation/changes/home (Available Database Refactorings)"
   (:require
     [clj-jdbcutil.core      :as sp]
     [clj-miscutil.core      :as mu]
@@ -28,7 +28,9 @@
       InsertDataChange LoadDataChange    LoadUpdateDataChange UpdateDataChange
       DeleteDataChange TagDatabaseChange StopChange
       ;; Architectural Refactorings
-      CreateIndexChange DropIndexChange)
+      CreateIndexChange DropIndexChange
+      ;; Custom Refactorings
+      RawSQLChange)
     (liquibase.statement DatabaseFunction)
     (liquibase.util      ISODateFormat)))
 
@@ -56,7 +58,7 @@
 
 ;; ===== Database refactorings =====
 
-;; Complete list here: http://www.liquibase.org/manual/home
+;; Complete list here: http://www.liquibase.org/documentation/changes/home
 
 ;; ----- Structural Refactorings -----
 
@@ -66,19 +68,23 @@
   "Return a Change instance that adds columns to an existing table
   (AddColumnChange).
   See also:
-    http://www.liquibase.org/manual/add_column
-    http://www.liquibase.org/manual/column"
+    http://www.liquibase.org/documentation/changes/add_column
+    http://www.liquibase.org/documentation/column"
   [table-name ^List columns
-   & {:keys [schema-name schema ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? AddColumnChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (coll? columns))
                                  (mu/verify-arg (mu/not-empty? columns))]}
   (let [change (AddColumnChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (.setTableName change (sp/db-iden table-name))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     (doseq [each columns]
       (.addColumn change (apply in/as-column-config each)))
     change))
@@ -90,24 +96,28 @@
   "Return a Change instance that renames a column in an existing table
   (RenameColumnChange).
   See also:
-    http://www.liquibase.org/manual/rename_column"
+    http://www.liquibase.org/documentation/changes/rename_column"
   [table-name old-column-name new-column-name
-   & {:keys [schema-name      schema    ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name     catalog   ; String/Keyword - subject to db-iden
+             schema-name      schema    ; String/Keyword - subject to db-iden
              column-data-type data-type ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? RenameColumnChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name      :schema
+                          :pre  [(mu/verify-opt #{:catalog-name     :catalog
+                                                  :schema-name      :schema
                                                   :column-data-type :data-type} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? old-column-name))
                                  (mu/verify-arg (mu/not-nil? new-column-name))]}
   (let [change  (RenameColumnChange.)
+        c-name (or catalog-name      catalog)
         s-name  (or schema-name      schema *schema*)
         cd-type (or column-data-type data-type)]
     (doto change
       (.setTableName     (sp/db-iden table-name))
       (.setOldColumnName (sp/db-iden old-column-name))
       (.setNewColumnName (sp/db-iden new-column-name)))
-    (if s-name  (.setSchemaName     change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName     change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName      change (sp/db-iden s-name)))
     (if cd-type (.setColumnDataType change (apply in/as-coltype
                                                   (mu/as-vector cd-type))))
     change))
@@ -119,21 +129,25 @@
   "Return a Change instance that modifies data type of a column in an existing
   table (ModifyDataTypeChange).
   See also:
-    http://www.liquibase.org/manual/modify_column"
+    http://www.liquibase.org/documentation/changes/modify_column"
   [table-name column-name new-data-type
-   & {:keys [schema-name schema ; String/Keyword - subject to `db-iden`
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? ModifyDataTypeChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))
                                  (mu/verify-arg (mu/not-nil? new-data-type))]}
   (let [change (ModifyDataTypeChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setTableName   (sp/db-iden table-name))
       (.setColumnName  (sp/db-iden column-name))
       (.setNewDataType (apply in/as-coltype (mu/as-vector new-data-type))))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -143,19 +157,23 @@
   "Return Change instance that drops a column from an existing table
   (DropColumnChange).
   See also:
-    http://www.liquibase.org/manual/drop_column"
+    http://www.liquibase.org/documentation/changes/drop_column"
   [table-name column-name
-   & {:keys [schema-name schema ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropColumnChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))]}
   (let [change (DropColumnChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setTableName  (sp/db-iden table-name))
       (.setColumnName (sp/db-iden column-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -164,31 +182,35 @@
 (defn ^AlterSequenceChange alter-sequence
   "Return a Change instance that alters a seuqence (AlterSequenceChange).
   See also:
-    http://www.liquibase.org/manual/alter_sequence"
+    http://www.liquibase.org/documentation/changes/alter_sequence"
   [seq-name increment-by
-   & {:keys [schema-name schema ; string/Keyword - subject to db-iden
-             max-value   max    ; number or string
-             min-value   min    ; number or string
-             ordered     ord    ; Boolean
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; string/Keyword - subject to db-iden
+             max-value    max     ; number or string
+             min-value    min     ; number or string
+             ordered      ord     ; Boolean
              ] :as opt}] {:post [(instance? AlterSequenceChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema
-                                                  :max-value   :max
-                                                  :min-value   :min
-                                                  :ordered     :ord} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
+                                                  :max-value    :max
+                                                  :min-value    :min
+                                                  :ordered      :ord} opt)
                                  (mu/verify-arg (mu/not-nil? seq-name))
                                  (mu/verify-arg (mu/not-nil? increment-by))]}
   (let [change (AlterSequenceChange.)
-        s-name (or schema-name schema *schema*)
-        max-v  (or max-value   max)
-        min-v  (or min-value   min)
-        ord-v  (or ordered     ord)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)
+        max-v  (or max-value    max)
+        min-v  (or min-value    min)
+        ord-v  (or ordered      ord)]
     (doto change
       (.setSequenceName (sp/db-iden seq-name))
       (.setIncrementBy (BigInteger. (str increment-by))))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
-    (if max-v  (.setMaxValue   change (BigInteger. (str max-v))))
-    (if min-v  (.setMinValue   change (BigInteger. (str min-v))))
-    (if ord-v  (.setOrdered    change ord-v))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
+    (if max-v  (.setMaxValue    change (BigInteger. (str max-v))))
+    (if min-v  (.setMinValue    change (BigInteger. (str min-v))))
+    (if ord-v  (.setOrdered     change ord-v))
     change))
 
 
@@ -197,23 +219,27 @@
 (defn ^CreateTableChange create-table
   "Return a Change instance that creates a table (CreateTableChange).
   See also:
-    http://www.liquibase.org/manual/create_table
-    http://www.liquibase.org/manual/column"
+    http://www.liquibase.org/documentation/changes/create_table
+    http://www.liquibase.org/documentation/column"
   [table-name ^List columns
-   & {:keys [schema-name schema ; String/Keyword - subject to db-iden
-             table-space tspace ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             table-space  tspace  ; String/Keyword - subject to db-iden
              remarks] :as opt}] {:post [(instance? CreateTableChange %)]
-                                 :pre  [(mu/verify-opt #{:schema-name :schema
-                                                         :table-space :tspace
+                                 :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                         :schema-name  :schema
+                                                         :table-space  :tspace
                                                          :remarks} opt)
                                         (mu/verify-arg (mu/not-nil?   table-name))
                                         (mu/verify-arg (coll?         columns))
                                         (mu/verify-arg (mu/not-empty? columns))]}
   (let [change  (CreateTableChange.)
-        s-name  (or schema-name schema *schema*)
-        t-space (or table-space tspace)]
+        c-name  (or catalog-name catalog)
+        s-name  (or schema-name  schema *schema*)
+        t-space (or table-space  tspace)]
     (.setTableName change (sp/db-iden table-name))
-    (if s-name  (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     (if t-space (.setTablespace change (sp/db-iden t-space)))
     (if remarks (.setRemarks    change remarks))
     (doseq [each columns]
@@ -243,19 +269,23 @@
 (defn ^RenameTableChange rename-table
   "Return a Change instance that renames a table (RenameTableChange).
   See also:
-    http://www.liquibase.org/manual/rename_table"
+    http://www.liquibase.org/documentation/changes/rename_table"
   [old-table-name new-table-name
-   & {:keys [schema-name schema ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? RenameTableChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? old-table-name))
                                  (mu/verify-arg (mu/not-nil? new-table-name))]}
   (let [change (RenameTableChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setOldTableName (sp/db-iden old-table-name))
       (.setNewTableName (sp/db-iden new-table-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -264,18 +294,22 @@
 (defn ^DropTableChange drop-table
   "Return a Change instance that drops a table (DropTableChange).
   See also:
-    http://www.liquibase.org/manual/drop_table"
+    http://www.liquibase.org/documentation/changes/drop_table"
   [table-name
-   & {:keys [schema-name         schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name        catalog ; String/Keyword - subject to db-iden
+             schema-name         schema  ; String/Keyword - subject to db-iden
              cascade-constraints cascade ; Boolean
              ] :as opt}] {:post [(instance? DropTableChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name         :schema
+                          :pre  [(mu/verify-opt #{:catalog-name        :catalog
+                                                  :schema-name         :schema
                                                   :cascade-constraints :cascade} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))]}
   (let [change (DropTableChange.)
+        c-name (or catalog-name        catalog)
         s-name (or schema-name         schema   *schema*)
         casc-c (or cascade-constraints cascade)]
     (.setTableName change (sp/db-iden table-name))
+    (if c-name (.setCatalogName        change (sp/db-iden c-name)))
     (if s-name (.setSchemaName         change (sp/db-iden s-name)))
     (if casc-c (.setCascadeConstraints change casc-c))
     change))
@@ -286,21 +320,25 @@
 (defn ^CreateViewChange create-view
   "Return a Change instance that creates a view (CreateViewChange).
   See also:
-    http://www.liquibase.org/manual/create_view"
+    http://www.liquibase.org/documentation/changes/create_view"
   [view-name ^String select-query
-   & {:keys [schema-name       schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name      catalog ; String/Keyword - subject to db-iden
+             schema-name       schema  ; String/Keyword - subject to db-iden
              replace-if-exists replace ; Boolean
              ] :as opt}] {:post [(instance? CreateViewChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name       :schema
+                          :pre  [(mu/verify-opt #{:catalog-name      :catalog
+                                                  :schema-name       :schema
                                                   :replace-if-exists :replace} opt)
                                  (mu/verify-arg (mu/not-nil? view-name))
                                  (mu/verify-arg (string?     select-query))]}
   (let [change (CreateViewChange.)
+        c-name (or catalog-name      catalog)
         s-name (or schema-name       schema  *schema*)
         repl-v (or replace-if-exists replace)]
     (doto change
       (.setViewName    (sp/db-iden view-name))
       (.setSelectQuery select-query))
+    (if c-name (.setCatalogName     change (sp/db-iden c-name)))
     (if s-name (.setSchemaName      change (sp/db-iden s-name)))
     (if repl-v (.setReplaceIfExists change repl-v))
     change))
@@ -311,19 +349,23 @@
 (defn ^RenameViewChange rename-view
   "Return a Change instance that renames a view (RenameViewChange).
   See also:
-    http://www.liquibase.org/manual/rename_view"
+    http://www.liquibase.org/documentation/changes/rename_view"
   [old-view-name new-view-name
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? RenameViewChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? old-view-name))
                                  (mu/verify-arg (mu/not-nil? new-view-name))]}
   (let [change (RenameViewChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setOldViewName (sp/db-iden old-view-name))
       (.setNewViewName (sp/db-iden new-view-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -332,16 +374,20 @@
 (defn ^DropViewChange drop-view
   "Return a Change instance that drops a view (DropViewChange).
   See also:
-    http://www.liquibase.org/manual/drop_view"
+    http://www.liquibase.org/documentation/changes/drop_view"
   [view-name
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropViewChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil?   view-name))]}
   (let [change (DropViewChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (.setViewName change (sp/db-iden view-name))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -350,12 +396,14 @@
 (defn ^MergeColumnChange merge-columns
   "Return a Change instance that merges columns (MergeColumnChange).
   See also:
-    http://www.liquibase.org/manual/merge_columns"
+    http://www.liquibase.org/documentation/changes/merge_columns"
   [table-name column1-name ^String join-string
    column2-name final-column-name final-column-type
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? MergeColumnChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column1-name))
                                  (mu/verify-arg (string?     join-string))
@@ -363,7 +411,8 @@
                                  (mu/verify-arg (mu/not-nil? final-column-name))
                                  (mu/verify-arg (mu/not-nil? final-column-type))]}
   (let [change (MergeColumnChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setTableName       (sp/db-iden table-name))
       (.setColumn1Name     (sp/db-iden column1-name))
@@ -372,7 +421,8 @@
       (.setFinalColumnName (sp/db-iden final-column-name))
       (.setFinalColumnType (apply in/as-coltype
                                   (mu/as-vector final-column-type))))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -382,7 +432,7 @@
   "Return a Change instance that creates a stored procedure
   (CreateProcedureChange).
   See also:
-    http://www.liquibase.org/manual/create_stored_procedure"
+    http://www.liquibase.org/documentation/changes/create_stored_procedure"
   [^String procedure-body
    & {:keys [comments  ; String
              ] :as opt}] {:post [(instance? CreateProcedureChange %)]
@@ -401,7 +451,7 @@
 (defn ^AddLookupTableChange add-lookup-table
   "Return a Change instance that adds a lookup table (AddLookupTableChange).
   See also:
-    http://www.liquibase.org/manual/add_lookup_table"
+    http://www.liquibase.org/documentation/changes/add_lookup_table"
   [existing-table-name existing-column-name
    new-table-name      new-column-name
    constraint-name
@@ -440,17 +490,20 @@
   "Return a Change instance that adds a NOT NULL constraint
   (AddNotNullConstraintChange).
   See also:
-    http://www.liquibase.org/manual/add_not-null_constraint"
+    http://www.liquibase.org/documentation/changes/add_not-null_constraint"
   [table-name column-name column-data-type
-   & {:keys [schema-name        schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name       catalog ; String/Keyword - subject to db-iden
+             schema-name        schema  ; String/Keyword - subject to db-iden
              default-null-value default ; String
              ] :as opt}] {:post [(instance? AddNotNullConstraintChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name        :schema
+                          :pre  [(mu/verify-opt #{:catalog-name       :catalog
+                                                  :schema-name        :schema
                                                   :default-null-value :default} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))
                                  (mu/verify-arg (mu/not-nil? column-data-type))]}
   (let [change (AddNotNullConstraintChange.)
+        c-name (or catalog-name        catalog)
         s-name  (or schema-name        schema  *schema*)
         n-value (or default-null-value default)]
     (doto change
@@ -458,7 +511,8 @@
       (.setColumnName     (sp/db-iden column-name))
       (.setColumnDataType (apply in/as-coltype
                                  (mu/as-vector column-data-type))))
-    (if s-name  (.setSchemaName       change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName       change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName        change (sp/db-iden s-name)))
     (if n-value (.setDefaultNullValue change n-value))
     change))
 
@@ -469,21 +523,25 @@
   "Return a Change instance that drops a NOT NULL constraint
   (DropNotNullConstraintChange).
   See also:
-    http://www.liquibase.org/manual/remove_not-null_constraint"
+    http://www.liquibase.org/documentation/changes/remove_not-null_constraint"
   [table-name column-name
-   & {:keys [schema-name      schema    ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name     catalog   ; String/Keyword - subject to db-iden
+             schema-name      schema    ; String/Keyword - subject to db-iden
              column-data-type data-type ; String/vector - subject to as-coltype
              ] :as opt}] {:post [(instance? DropNotNullConstraintChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name      :schema
+                          :pre  [(mu/verify-opt #{:catalog-name     :catalog
+                                                  :schema-name      :schema
                                                   :column-data-type :data-type} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))]}
   (let [change (DropNotNullConstraintChange.)
+        c-name (or catalog-name     catalog)
         s-name (or schema-name      schema    *schema*)
         d-type (or column-data-type data-type)]
     (doto change
       (.setTableName  (sp/db-iden table-name))
       (.setColumnName (sp/db-iden column-name)))
+    (if c-name (.setCatalogName    change (sp/db-iden c-name)))
     (if s-name (.setSchemaName     change (sp/db-iden s-name)))
     (if d-type (.setColumnDataType change (apply in/as-coltype
                                                  (mu/as-vector d-type))))
@@ -496,15 +554,17 @@
   "Return a Change instance that adds a UNIQUE constraint
   (AddUniqueConstraintChange).
   See also:
-    http://www.liquibase.org/manual/add_unique_constraint"
+    http://www.liquibase.org/documentation/changes/add_unique_constraint"
   [table-name column-names constraint-name
-   & {:keys [schema-name        schema ; String/Keyword - subject to db-iden
-             table-space        tspace ; String/Keyword - subject to db-iden
-             deferrable         defer  ; Boolean
-             initially-deferred idefer ; Boolean
-             disabled                  ; Boolean
+   & {:keys [catalog-name       catalog ; String/Keyword - subject to db-iden
+             schema-name        schema  ; String/Keyword - subject to db-iden
+             table-space        tspace  ; String/Keyword - subject to db-iden
+             deferrable         defer   ; Boolean
+             initially-deferred idefer  ; Boolean
+             disabled                   ; Boolean
              ] :as opt}] {:post [(instance? AddUniqueConstraintChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name        :schema
+                          :pre  [(mu/verify-opt #{:catalog-name       :catalog
+                                                  :schema-name        :schema
                                                   :table-space        :tspace
                                                   :deferrable         :defer
                                                   :initially-deferred :idefer
@@ -513,6 +573,7 @@
                                  (mu/verify-arg (mu/not-nil? column-names))
                                  (mu/verify-arg (mu/not-nil? constraint-name))]}
   (let [change (AddUniqueConstraintChange.)
+        c-name (or catalog-name       catalog)
         s-name (or schema-name        schema *schema*)
         t-name (or table-space        tspace)
         df-val (or deferrable         defer)
@@ -522,6 +583,7 @@
       (.setTableName      (sp/db-iden table-name))
       (.setColumnNames    (in/as-dbident-names column-names))
       (.setConstraintName (sp/db-iden constraint-name)))
+    (if c-name (.setCatalogName       change (sp/db-iden c-name)))
     (if s-name (.setSchemaName        change (sp/db-iden s-name)))
     (if t-name (.setTablespace        change (sp/db-iden t-name)))
     (if df-val (.setDeferrable        change df-val))
@@ -536,19 +598,23 @@
   "Return a Change instance that drops a UNIQUE constraint
   (DropUniqueConstraintChange).
   See also:
-    http://www.liquibase.org/manual/drop_unique_constraint"
+    http://www.liquibase.org/documentation/changes/drop_unique_constraint"
   [table-name constraint-name
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropUniqueConstraintChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? constraint-name))]}
   (let [change (DropUniqueConstraintChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setTableName      (sp/db-iden table-name))
       (.setConstraintName (sp/db-iden constraint-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -557,17 +623,19 @@
 (defn ^CreateSequenceChange create-sequence
   "Return a Change instance that creates a sequence (CreateSequenceChange).
   See also:
-    http://www.liquibase.org/manual/create_sequence"
+    http://www.liquibase.org/documentation/changes/create_sequence"
   [sequence-name
-   & {:keys [schema-name  schema ; String/Keyword - subject to db-iden
-             start-value  start  ; BigInteger
-             increment-by incby  ; BigInteger
-             max-value    max    ; BigInteger
-             min-value    min    ; BigInteger
-             ordered      ord    ; Boolean
-             cycle        cyc    ; Boolean
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             start-value  start   ; BigInteger
+             increment-by incby   ; BigInteger
+             max-value    max     ; BigInteger
+             min-value    min     ; BigInteger
+             ordered      ord     ; Boolean
+             cycle        cyc     ; Boolean
              ] :as opt}] {:post [(instance? CreateSequenceChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name  :schema
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
                                                   :start-value  :start
                                                   :increment-by :incby
                                                   :max-value    :max
@@ -576,6 +644,7 @@
                                                   :cycle        :cyc} opt)
                                  (mu/verify-arg (mu/not-nil? sequence-name))]}
   (let [change (CreateSequenceChange.)
+        c-name (or catalog-name catalog)
         s-name (or schema-name  schema *schema*)
         str-v  (or start-value  start)
         inc-v  (or increment-by incby)
@@ -584,6 +653,7 @@
         ord-v  (or ordered      ord)
         cyc-v  (or cycle        cyc)]
     (.setSequenceName change (sp/db-iden sequence-name))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
     (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     (if str-v  (.setStartValue  change (BigInteger. (str str-v))))
     (if inc-v  (.setIncrementBy change (BigInteger. (str inc-v))))
@@ -599,16 +669,20 @@
 (defn ^DropSequenceChange drop-sequence
   "Return a Change instance that drops a sequence (DropSequenceChange).
   See also:
-    http://www.liquibase.org/manual/drop_sequence"
+    http://www.liquibase.org/documentation/changes/drop_sequence"
   [sequence-name
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropSequenceChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? sequence-name))]}
   (let [change (DropSequenceChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (.setSequenceName change (sp/db-iden sequence-name))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -618,22 +692,26 @@
   "Return a Change instance that converts an existing column to be an
   auto-increment column (AddAutoIncrementChange).
   See also:
-    http://www.liquibase.org/manual/add_auto-increment"
+    http://www.liquibase.org/documentation/changes/add_auto-increment"
   [table-name column-name column-data-type
-   & {:keys [schema-name schema  ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? AddAutoIncrementChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))
                                  (mu/verify-arg (mu/not-nil? column-data-type))]}
   (let [change (AddAutoIncrementChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setTableName      (sp/db-iden table-name))
       (.setColumnName     (sp/db-iden column-name))
       (.setColumnDataType (apply in/as-coltype
                                  (mu/as-vector column-data-type))))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -643,25 +721,29 @@
   "Return a Change instance that adds a default value to the database definition
   for the specified column (AddDefaultValueChange).
   See also:
-    http://www.liquibase.org/manual/add_default_value"
+    http://www.liquibase.org/documentation/changes/add_default_value"
   [table-name column-name default-value
-   & {:keys [schema-name      schema    ; String/Keyword - subject to db-iden
+   & {:keys [catalog-name     catalog   ; String/Keyword - subject to db-iden
+             schema-name      schema    ; String/Keyword - subject to db-iden
              column-data-type data-type
              ] :as opt}] {:post [(instance? AddDefaultValueChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name      :schema
+                          :pre  [(mu/verify-opt #{:catalog-name     :catalog
+                                                  :schema-name      :schema
                                                   :column-data-type :data-type} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))]}
   (let [change (AddDefaultValueChange.)
+        c-name (or catalog-name     catalog)
         s-name (or schema-name      schema    *schema*)
         d-type (or column-data-type data-type)]
     (doto change
       (.setTableName  (sp/db-iden table-name))
       (.setColumnName (sp/db-iden column-name)))
     (in/add-default-value change default-value)
+    (if c-name (.setCatalogName    change (sp/db-iden c-name)))
     (if s-name (.setSchemaName     change (sp/db-iden s-name)))
     (if d-type (.setColumnDataType change (apply in/as-coltype
-                                            (mu/as-vector d-type))))
+                                                 (mu/as-vector d-type))))
     change))
 
 
@@ -671,24 +753,28 @@
   "Return a Change instance that removes a database default value for a column
   (DropDefaultValueChange).
   See also:
-    http://www.liquibase.org/manual/drop_default_value"
+    http://www.liquibase.org/documentation/changes/drop_default_value"
   [table-name column-name
-   & {:keys [schema-name      schema  ; String
+   & {:keys [catalog-name     catalog ; String/Keyword - subject to db-iden
+             schema-name      schema  ; String/Keyword - subject to db-iden
              column-data-type data-type
              ] :as opt}] {:post [(instance? DropDefaultValueChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name      :schema
+                          :pre  [(mu/verify-opt #{:catalog-name     :catalog
+                                                  :schema-name      :schema
                                                   :column-data-type :data-type} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-name))]}
   (let [change (DropDefaultValueChange.)
+        c-name (or catalog-name     catalog)
         s-name (or schema-name      schema    *schema*)
         d-type (or column-data-type data-type)]
     (doto change
       (.setTableName  (sp/db-iden table-name))
       (.setColumnName (sp/db-iden column-name)))
+    (if c-name (.setCatalogName    change (sp/db-iden c-name)))
     (if s-name (.setSchemaName     change (sp/db-iden s-name)))
     (if d-type (.setColumnDataType change (apply in/as-coltype
-                                            (mu/as-vector d-type))))
+                                                 (mu/as-vector d-type))))
     change))
 
 
@@ -700,7 +786,7 @@
   "Return a Change instance that adds a foreign key constraint to an existing
   column (AddForeignKeyConstraintChange).
   See also:
-    http://www.liquibase.org/manual/add_foreign_key_constraint"
+    http://www.liquibase.org/documentation/changes/add_foreign_key_constraint"
   [constraint-name base-table-name base-column-names
    referenced-table-name referenced-column-names
    & {:keys [base-table-schema-name       base-schema ; String
@@ -749,19 +835,23 @@
   "Return a Change instance that drops an existing foreign key
   (DropForeignKeyConstraintChange).
   See also:
-    http://www.liquibase.org/manual/drop_foreign_key_constraint"
+    http://www.liquibase.org/documentation/changes/drop_foreign_key_constraint"
   [constraint-name base-table-name
-   & {:keys [schema-name schema  ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropForeignKeyConstraintChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? constraint-name))
                                  (mu/verify-arg (mu/not-nil? base-table-name))]}
   (let [change (DropForeignKeyConstraintChange.)
-        s-name (or schema-name schema *schema*)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)]
     (doto change
       (.setConstraintName (sp/db-iden constraint-name))
       (.setBaseTableName  (sp/db-iden base-table-name)))
-    (if s-name (.setBaseTableSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setBaseTableCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setBaseTableSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -771,25 +861,29 @@
   "Return a Change instance that adds creates a primary key out of an existing
   column or set of columns (AddPrimaryKeyChange).
   See also:
-    http://www.liquibase.org/manual/add_primary_key_constraint"
+    http://www.liquibase.org/documentation/changes/add_primary_key_constraint"
   [table-name column-names constraint-name
-   & {:keys [schema-name schema ; String
-             table-space tspace ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
+             table-space tspace   ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? AddPrimaryKeyChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema
-                                                  :table-space :tspace} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
+                                                  :table-space  :tspace} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (mu/not-nil? column-names))
                                  (mu/verify-arg (mu/not-nil? constraint-name))]}
   (let [change (AddPrimaryKeyChange.)
-        s-name (or schema-name schema *schema*)
-        t-name (or table-space tspace)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)
+        t-name (or table-space  tspace)]
     (doto change
       (.setTableName      (sp/db-iden table-name))
       (.setColumnNames    (in/as-dbident-names column-names))
       (.setConstraintName (sp/db-iden constraint-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
-    (if t-name (.setTablespace change (sp/db-iden t-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
+    (if t-name (.setTablespace  change (sp/db-iden t-name)))
     change))
 
 
@@ -799,20 +893,24 @@
   "Return a Change instance that drops an existing primary key
   (DropPrimaryKeyChange).
   See also:
-    http://www.liquibase.org/manual/drop_primary_key_constraint"
+    http://www.liquibase.org/documentation/changes/drop_primary_key_constraint"
   [table-name
-   & {:keys [schema-name     schema ; String
-             constraint-name constr ; String
+   & {:keys [catalog-name catalog   ; String/Keyword - subject to db-iden
+             schema-name     schema ; String/Keyword - subject to db-iden
+             constraint-name constr ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropPrimaryKeyChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name     :schema
+                          :pre  [(mu/verify-opt #{:catalog-name    :catalog
+                                                  :schema-name     :schema
                                                   :constraint-name :constr} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))]}
-  (let [change (DropPrimaryKeyChange.)
-        s-name (or schema-name     schema *schema*)
-        c-name (or constraint-name constr)]
+  (let [change    (DropPrimaryKeyChange.)
+        c-name    (or catalog-name    catalog)
+        s-name    (or schema-name     schema *schema*)
+        cons-name (or constraint-name constr)]
     (.setTableName change (sp/db-iden table-name))
-    (if s-name (.setSchemaName     change (sp/db-iden s-name)))
-    (if c-name (.setConstraintName change (sp/db-iden c-name)))
+    (if c-name (.setCatalogName       change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName        change (sp/db-iden s-name)))
+    (if cons-name (.setConstraintName change (sp/db-iden cons-name)))
     change))
 
 
@@ -824,20 +922,24 @@
   "Return a Change instance that inserts data into an existing table
   (InsertDataChange).
   See also:
-    http://www.liquibase.org/manual/insert_data"
+    http://www.liquibase.org/documentation/changes/insert_data"
   [table-name column-value-map
-   & {:keys [schema-name schema ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? InsertDataChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema} opt)
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (map?        column-value-map))]}
   (let [change (InsertDataChange.)
-        s-name (or schema-name schema *schema*)
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)
         cols-v (map (fn [[n v]] (in/new-column-value n v)) column-value-map)]
     (.setTableName change (sp/db-iden table-name))
     (doseq [each cols-v]
       (.addColumn change ^ColumnConfig each))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -856,26 +958,30 @@
     :schema   (keyword/String) schema name - defaults to the default schema
     :encoding (String)         encoding of the CSV file - defaults to UTF-8
   See also:
-    http://www.liquibase.org/manual/load_data"
+    http://www.liquibase.org/documentation/changes/load_data"
   [table-name ^String csv-filename columns-spec
-   & {:keys [schema-name schema ; String
-             encoding    enc    ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             encoding     enc     ; String
              ] :as opt}] {:post [(instance? LoadDataChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name :schema
                                                   :encoding    :enc} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (string?     csv-filename))
                                  (mu/verify-arg (coll?       columns-spec))]}
   (let [change (LoadDataChange.)
-        s-name (or schema-name schema *schema*)
-        enc-v  (or encoding    enc)]
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)
+        enc-v  (or encoding     enc)]
     (doto change
       (.setTableName (sp/db-iden table-name))
       (.setFile      csv-filename))
     (doseq [each columns-spec]
       (.addColumn change (apply in/load-data-column-config each)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
-    (if enc-v  (.setEncoding   change (mu/as-string enc-v)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
+    (if enc-v  (.setEncoding    change (mu/as-string enc-v)))
     change))
 
 
@@ -898,19 +1004,22 @@
     :schema   (keyword/String) schema name - defaults to the default schema
     :encoding (String)         encoding of the CSV file - defaults to UTF-8
   See also:
-    http://www.liquibase.org/manual/load_update_data"
+    http://www.liquibase.org/documentation/changes/load_update_data"
   [table-name ^String csv-filename primary-key-cols columns-spec
-   & {:keys [schema-name schema ; String
-             encoding    enc    ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name schema   ; String/Keyword - subject to db-iden
+             encoding    enc      ; String
              ] :as opt}] {:post [(instance? LoadUpdateDataChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name :schema
                                                   :encoding    :enc} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (string?     csv-filename))
                                  (mu/verify-arg (mu/not-nil? primary-key-cols))
                                  (mu/verify-arg (coll?       columns-spec))]}
   (let [change (LoadUpdateDataChange.)
-        s-name (or schema-name schema *schema*)
+        c-name (or catalog-name catalog)
+        s-name (or schema-name  schema *schema*)
         enc-v  (or encoding    enc)]
     (doto change
       (.setTableName  (sp/db-iden table-name))
@@ -918,8 +1027,9 @@
       (.setPrimaryKey (in/as-dbident-names primary-key-cols)))
     (doseq [each columns-spec]
       (.addColumn change (apply in/load-data-column-config each)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
-    (if enc-v  (.setEncoding   change (mu/as-string enc-v)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
+    (if enc-v  (.setEncoding    change (mu/as-string enc-v)))
     change))
 
 
@@ -929,22 +1039,26 @@
   "Return a Change instance that updates data in an existing table
   (UpdateDataChange).
   See also:
-    http://www.liquibase.org/manual/update_data"
+    http://www.liquibase.org/documentation/changes/update_data"
   [table-name column-name-value-map
-   & {:keys [schema-name  schema ; String
-             where-clause where  ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             where-clause where   ; String
              ] :as opt}] {:post [(instance? UpdateDataChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name  :schema
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
                                                   :where-clause :where} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (map?        column-name-value-map))]}
   (let [change   (UpdateDataChange.)
+        c-name   (or catalog-name catalog)
         s-name   (or schema-name  schema *schema*)
         w-clause (or where-clause where)]
     (.setTableName change (sp/db-iden table-name))
     (doseq [[n v] column-name-value-map]
       (.addColumn change (in/new-column-value n v)))
-    (if s-name   (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name   (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name   (.setSchemaName  change (sp/db-iden s-name)))
     (if w-clause (.setWhereClause change w-clause))
     change))
 
@@ -955,19 +1069,23 @@
   "Return a Change instance that deletes data from an existing table
   (DeleteDataChange).
   See also:
-    http://www.liquibase.org/manual/delete_data"
+    http://www.liquibase.org/documentation/changes/delete_data"
   [table-name
-   & {:keys [schema-name  schema ; String
-             where-clause where  ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             where-clause where   ; String
              ] :as opt}] {:post [(instance? DeleteDataChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name  :schema
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
                                                   :where-clause :where} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))]}
   (let [change   (DeleteDataChange.)
+        c-name   (or catalog-name catalog)
         s-name   (or schema-name  schema *schema*)
         w-clause (or where-clause where)]
     (.setTableName change (sp/db-iden table-name))
-    (if s-name   (.setWhereClause change (sp/db-iden s-name)))
+    (if c-name   (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name   (.setSchemaName  change (sp/db-iden s-name)))
     (if w-clause (.setSchemaName  change w-clause))
     change))
 
@@ -978,7 +1096,7 @@
   "Return a Change instance that applies a tag to the database for future
   rollback (TagDatabaseChange).
   See also:
-    http://www.liquibase.org/manual/tag_database"
+    http://www.liquibase.org/documentation/changes/tag_database"
   [tag] {:post [(instance? TagDatabaseChange %)]
          :pre  [(mu/verify-arg (mu/not-nil? tag))]}
   (let [change (TagDatabaseChange.)]
@@ -992,14 +1110,14 @@
   "Return a Change instance that stops LiquiBase execution with a message
   (StopChange). Mainly useful for debugging and stepping through a changelog.
   See also:
-    http://www.liquibase.org/manual/stop"
+    http://www.liquibase.org/documentation/changes/stop"
   ([] {:post [(instance? StopChange %)]}
-    (StopChange.))
+   (StopChange.))
   ([^String message] {:post [(instance? StopChange %)]
                       :pre  [(mu/verify-arg (string? message))]}
-    (let [change (StopChange.)]
-      (.setMessage change message)
-      change)))
+   (let [change (StopChange.)]
+     (.setMessage change message)
+     change)))
 
 
 ;; ----- Architectural Refactorings -----
@@ -1010,20 +1128,23 @@
   "Return a Change instance that creates an index on an existing column or set
   of columns (CreateIndexChange).
   See also:
-    http://www.liquibase.org/manual/create_index"
+    http://www.liquibase.org/documentation/changes/create_index"
   [table-name ^List column-names
-   & {:keys [schema-name  schema ; String
-             index-name   index  ; String
-             unique       uniq   ; Boolean
-             table-space  tspace ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
+             index-name   index   ; String/Keyword - subject to db-iden
+             unique       uniq    ; Boolean
+             table-space  tspace  ; String
              ] :as opt}] {:post [(instance? CreateIndexChange %)]
-                          :pre  [(mu/verify-opt #{:schema-name :schema
-                                                  :index-name  :index
-                                                  :unique      :uniq
+                          :pre  [(mu/verify-opt #{:catalog-name :catalog
+                                                  :schema-name  :schema
+                                                  :index-name   :index
+                                                  :unique       :uniq
                                                   :table-space :tspace} opt)
                                  (mu/verify-arg (mu/not-nil? table-name))
                                  (mu/verify-arg (coll? column-names))]}
   (let [change  (CreateIndexChange.)
+        c-name  (or catalog-name catalog)
         s-name  (or schema-name  schema *schema*)
         i-name  (or index-name   index)
         uniq-v  (or unique       uniq)
@@ -1031,7 +1152,8 @@
     (.setTableName change (sp/db-iden table-name))
     (doseq [each column-names]
       (.addColumn change (in/new-column-value each "")))
-    (if s-name  (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     (if i-name  (.setIndexName  change (sp/db-iden i-name)))
     (if uniq-v  (.setUnique     change uniq-v))
     (if t-space (.setTablespace change t-space))
@@ -1043,19 +1165,22 @@
 (defn ^DropIndexChange drop-index
   "Return a Change instance that drops an existing index (DropIndexChange).
   See also:
-    http://www.liquibase.org/manual/drop_index"
+    http://www.liquibase.org/documentation/changes/drop_index"
   [index-name table-name
-   & {:keys [schema-name  schema ; String
+   & {:keys [catalog-name catalog ; String/Keyword - subject to db-iden
+             schema-name  schema  ; String/Keyword - subject to db-iden
              ] :as opt}] {:post [(instance? DropIndexChange %)]
                           :pre  [(mu/verify-opt #{:schema-name :schema} opt)
                                  (mu/verify-arg (mu/not-nil? index-name))
                                  (mu/verify-arg (mu/not-nil? table-name))]}
   (let [change (DropIndexChange.)
+        c-name (or catalog-name catalog)
         s-name (or schema-name  schema *schema*)]
     (doto change
       (.setIndexName (sp/db-iden index-name))
       (.setTableName (sp/db-iden table-name)))
-    (if s-name (.setSchemaName change (sp/db-iden s-name)))
+    (if c-name (.setCatalogName change (sp/db-iden c-name)))
+    (if s-name (.setSchemaName  change (sp/db-iden s-name)))
     change))
 
 
@@ -1065,13 +1190,39 @@
 ;; TODO
 
 ;; Custom SQL
-;; TODO
+(defn ^RawSQLChange sql
+  "Allows execution of arbitrary SQL. This change can be used when existing
+   changes are either don't exist, are not flexible enough, or buggy. (RawSQLChange).
+  See also:
+    http://www.liquibase.org/documentation/changes/sql"
+  [sql
+   & {:keys [comment
+             dbms
+             end-delimiter
+             split-statements
+             strip-comments
+             ] :as opt}] {:post [(instance? RawSQLChange %)]
+                          :pre  [(mu/verify-opt #{:comment
+                                                  :dbms
+                                                  :end-delimiter
+                                                  :split-statements
+                                                  :strip-comments} opt)
+                                 (mu/verify-arg (mu/not-nil? sql))]}
+  (let [change (RawSQLChange.)]
+    (doto change
+      (.setSql sql))
+    (if comment          (.setComment         change comment))
+    (if dbms             (.setDbms            change dbms))
+    (if end-delimiter    (.setEndDelimiter    change end-delimiter))
+    (if split-statements (.setSplitStatements change split-statements))
+    (if strip-comments   (.setStripComments   change strip-comments))
+    change))
 
-;; Custom SQL File
+;; Custom SQL File .SQLFileChange
 ;; TODO
 
 ;; Custom Refactoring Class
 ;; TODO
 
-;; Execute Shell Command
+;; Execute Shell Command ExecuteShellCommandChange.
 ;; TODO

--- a/src/clj_liquibase/internal.clj
+++ b/src/clj_liquibase/internal.clj
@@ -4,7 +4,7 @@
     [clj-jdbcutil.core :as sp]
     [clj-miscutil.core :as mu])
   (:import
-    (liquibase.database.structure Column)
+    (liquibase.structure.core Column)
     (liquibase.change      ColumnConfig ConstraintsConfig)
     (liquibase.change.core LoadDataColumnConfig)
     (liquibase.statement   DatabaseFunction)
@@ -25,7 +25,7 @@
     (coltype :char 80)    => \"char(80)\"
     (coltype :float 17 5) => \"float(17, 5)\"
   Note: This function is called during constructing column-config.
-  See also: http://www.liquibase.org/manual/column"
+  See also: http://www.liquibase.org/documentation/column"
   [t & more]
   (str (sp/db-iden t)
     (if (mu/not-empty? more) (apply str "(" (mu/comma-sep-str more) ")"))))
@@ -73,7 +73,7 @@
     :index  (Number)
     :header (Keyword/String)
   See also:
-    http://www.liquibase.org/manual/load_data"
+    http://www.liquibase.org/documentation/changes/load_data"
   [colname coltype
    & {:keys [index  ; Integer
              header
@@ -209,7 +209,7 @@
     [:birth-date :date          :null false]
   See also:
     as-coltype
-    http://www.liquibase.org/manual/column"
+    http://www.liquibase.org/documentation/column"
   [colname coltype ; coltype (mixed) - keyword, string, vector (1st arg: db-iden)
    & {:keys [default-value          default  ; String/Number/Date/Boolean/DatabaseFunction
              auto-increment         autoinc  ; Boolean
@@ -266,7 +266,7 @@
     (if-nn c-uniq     (.setUnique               con ^Boolean   c-uniq     ))
     (if-nn c-ucname   (.setUniqueConstraintName con ^String  (sp/db-iden
                                                                c-ucname  )))
-    (if-nn c-check    (.setCheck                con ^String    c-check    ))
+    (if-nn c-check    (.setCheckConstraint      con ^String    c-check    ))
     (if-nn c-dcascade (.setDeleteCascade        con ^Boolean   c-dcascade ))
     (if-nn c-fkname   (.setForeignKeyName       con ^String  (sp/db-iden
                                                                c-fkname  )))

--- a/src/clj_liquibase/precondition.clj
+++ b/src/clj_liquibase/precondition.clj
@@ -1,7 +1,7 @@
 (ns clj-liquibase.precondition
   "Clojure wrappers for liquibase.change.Change implementations.
   See also:
-    http://www.liquibase.org/manual/home (Available Database Refactorings)"
+    http://www.liquibase.org/documentation/index (Available Database Refactorings)"
   (:require
     [clj-jdbcutil.core      :as sp]
     [clj-miscutil.core      :as mu]
@@ -252,7 +252,7 @@
     :on-update-sql What to do in updateSQL mode; either of
                      :run, :fail, :ignore
   See also:
-    http://www.liquibase.org/manual/preconditions"
+    http://www.liquibase.org/documentation/preconditions"
   [pre-cond-list
    & {:keys [on-fail       ; onFail         -- What to do when preconditions fail
              on-fail-msg   ; onFailMessage  -- Custom message to output when preconditions fail

--- a/test/clj_liquibase/example.clj
+++ b/test/clj_liquibase/example.clj
@@ -26,15 +26,22 @@
                          [:name   [:varchar 40] :null false]
                          [:gender [:char 1]     :null false]])))
 
+(def ct-change3 (mu/! (ch/sql "SELECT * FROM sampletable1")))
+
 (def changeset-1 ["id=1" "author=shantanu" [ct-change1]])
 
 
 (def changeset-2 ["id=2" "author=shantanu" [ct-change2]])
 
 
+(def changeset-3 ["id=3" "author=shantanu" [ct-change3]])
+
+
 (lb/defchangelog changelog-1 "example" [changeset-1])
 
 (lb/defchangelog changelog-2 "example" [changeset-1 changeset-2])
+
+(lb/defchangelog changelog-3 "example" [changeset-1 changeset-2 changeset-3])
 
 
 ;; ----- execute
@@ -55,6 +62,14 @@
     (lb/with-lb
       (lb/update changelog-2)
       (lb/tag "tag2"))))
+
+(defn update-3
+  []
+  (spec/with-connection
+    dbspec
+    (lb/with-lb
+      (lb/update changelog-3)
+      (lb/tag "tag3"))))
 
 (defn rollback-to-1
   []

--- a/test/clj_liquibase/test_change.clj
+++ b/test/clj_liquibase/test_change.clj
@@ -22,7 +22,9 @@
       InsertDataChange LoadDataChange    LoadUpdateDataChange UpdateDataChange
       DeleteDataChange TagDatabaseChange StopChange
       ;; Architectural Refactorings
-      CreateIndexChange DropIndexChange)
+      CreateIndexChange DropIndexChange
+      ;; Custom Refactorings
+      RawSQLChange)
     (liquibase.statement DatabaseFunction)
     (liquibase.util      ISODateFormat))
   (:use clj-liquibase.test-util)
@@ -527,6 +529,15 @@
       with-schema-name
       with-schema)))
 
+(deftest test-sql
+  (testing "sql"
+    (test-change RawSQLChange
+                 (partial change/sql "SELECT * FROM DATABASECHAGELOG")
+                 ["With :comment value"          :comment         "This is a comment"]
+                 ["With :dbms value"             :dbms            "h2"]
+                 ["With :end-delimiter value"    :end-delimiter    ";"]
+                 ["With :split-statements value" :split-statements true]
+                 ["With :strip-comments value"   :strip-comments   true])))
 
 (defn test-ns-hook []
   ;; ----- Structural Refactorings -----

--- a/test/clj_liquibase/test_internal.clj
+++ b/test/clj_liquibase/test_internal.clj
@@ -3,11 +3,11 @@
     [clj-liquibase.internal :as in]
     [clj-liquibase.change   :as ch])
   (:import
-    (liquibase.database.structure Column)
-    (liquibase.change      ColumnConfig ConstraintsConfig)
-    (liquibase.change.core LoadDataColumnConfig)
-    (liquibase.statement   DatabaseFunction)
-    (liquibase.util        ISODateFormat)
+    (liquibase.structure.core Column)
+    (liquibase.change         ColumnConfig ConstraintsConfig)
+    (liquibase.change.core    LoadDataColumnConfig)
+    (liquibase.statement      DatabaseFunction)
+    (liquibase.util           ISODateFormat)
     (java.util Date))
   (:use clojure.test))
 


### PR DESCRIPTION
This change upgrades to liquibase 3.0.8, and add implementation from RawSqlChange. Also fixes links to point to latest liquibase web site.
