### PR TITLE
Exclude clojure.core/update.

### DIFF
--- a/src/clj_liquibase/cli.clj
+++ b/src/clj_liquibase/cli.clj
@@ -1,4 +1,5 @@
 (ns clj-liquibase.cli
+  (:refer-clojure :exclude [update])
   (:require
     [clojure.java.io :as io]
     [clojure.string  :as sr]

--- a/src/clj_liquibase/core.clj
+++ b/src/clj_liquibase/core.clj
@@ -2,6 +2,7 @@
   "Expose functions from the Liquibase library.
   See also:
     http://www.liquibase.org/documentation/index.html"
+  (:refer-clojure :exclude [update])
   (:require
     [clojure.string    :as sr]
     [clj-jdbcutil.core :as sp]


### PR DESCRIPTION
Clojure 1.7 adds an update function. Exclude it so warnings are no
longer emitted.